### PR TITLE
Relocate Script tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
-<script src="https://cdn.freecodecamp.org/testable-projects-fcc/v1/bundle.js"></script>
 <head>
+  <script src="https://cdn.freecodecamp.org/testable-projects-fcc/v1/bundle.js"></script>
   <link rel="stylesheet" type="text/css" href="index.css">
   </link>
   </head>


### PR DESCRIPTION
The Script tag needs to be relocated to within either the head or body elements to allow the FCC script to work.